### PR TITLE
Use .watchmanconfig to seed Watchfiles filter

### DIFF
--- a/src/django_watchfiles/__init__.py
+++ b/src/django_watchfiles/__init__.py
@@ -1,10 +1,34 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Generator
+from typing import Generator, Optional, Sequence, Union
+import json
 
 import watchfiles
 from django.utils import autoreload
+
+
+class WatchmanConfigFilter(watchfiles.DefaultFilter):
+    allowed_extensions = ".py"
+
+    def __init__(
+        self,
+        *,
+        ignore_dirs: Optional[Sequence[str]] = None,
+        ignore_entity_patterns: Optional[Sequence[str]] = None,
+        ignore_paths: Optional[Sequence[Union[str, Path]]] = None,
+    ) -> None:
+        if ignore_dirs is None:
+            with open(".watchmanconfig") as inf:
+                watchmanconfig = json.load(inf)
+            pattern_set = set(watchmanconfig["ignore_dirs"])
+            pattern_set.add(watchfiles.DefaultFilter.ignore_dirs)
+            ignore_dirs = list(pattern_set)
+        super().__init__(
+            ignore_dirs=ignore_dirs,
+            ignore_entity_patterns=ignore_entity_patterns,
+            ignore_paths=ignore_paths,
+        )
 
 
 class WatchfilesReloader(autoreload.BaseReloader):
@@ -17,7 +41,9 @@ class WatchfilesReloader(autoreload.BaseReloader):
     def tick(self) -> Generator[None, None, None]:
         watched_files = list(self.watched_files(include_globs=False))
         roots = autoreload.common_roots(self.watched_roots(watched_files))
-        watcher = watchfiles.watch(*roots, debug=True)
+        watcher = watchfiles.watch(
+            *roots, watch_filter=WatchmanConfigFilter(), debug=True
+        )
         for file_changes in watcher:
             for _change, path in file_changes:
                 self.notify_file_changed(Path(path))


### PR DESCRIPTION
I was using watchman for reloading django. I tried django-watchfiles, but the default filter wasn't enough for my use case. Since I already had a .watchmanconfig for my watch ignore lists, I decided to use it in a custom filter for watchfiles. Not sure this is the best design, but something like this will be useful.