### PR TITLE
Manage watchfiles settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.3.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -14,24 +14,24 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/pre-commit/mirrors-prettier
-  rev: v2.6.0
+  rev: v3.0.0-alpha.0
   hooks:
     - id: prettier
       types_or:
         - css
 - repo: https://github.com/standard/standard
-  rev: v17.0.0-2
+  rev: v17.0.0
   hooks:
     - id: standard
       args:
       - --env=browser
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.31.1
+  rev: v2.37.3
   hooks:
   - id: pyupgrade
     args: [--py37-plus]
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.8.0
   hooks:
   - id: black
 - repo: https://github.com/asottile/blacken-docs
@@ -45,7 +45,7 @@ repos:
   hooks:
   - id: isort
 - repo: https://github.com/PyCQA/flake8
-  rev: 4.0.1
+  rev: 5.0.4
   hooks:
   - id: flake8
     additional_dependencies:
@@ -59,6 +59,6 @@ repos:
   - id: check-manifest
     args: [--no-build-isolation]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.941
+  rev: v0.971
   hooks:
   - id: mypy

--- a/src/django_watchfiles/__init__.py
+++ b/src/django_watchfiles/__init__.py
@@ -1,13 +1,29 @@
 from __future__ import annotations
 
+import os
+import signal
+import sys
+from collections.abc import Callable, Generator
 from pathlib import Path
-from typing import Generator
+from typing import Any
 
 import watchfiles
+from django.conf import settings
 from django.utils import autoreload
+from django.utils.autoreload import (
+    DJANGO_AUTORELOAD_ENV,
+    logger,
+    restart_with_reloader,
+    start_django,
+)
+from django.utils.module_loading import import_string
 
 
 class WatchfilesReloader(autoreload.BaseReloader):
+    def __init__(self, watchfiles_settings: dict[str, Any]) -> None:
+        super().__init__()
+        self.watchfiles_settings = watchfiles_settings
+
     def watched_roots(self, watched_files: list[Path]) -> frozenset[Path]:
         extra_directories = self.directory_globs.keys()
         watched_file_dirs = {f.parent for f in watched_files}
@@ -17,15 +33,33 @@ class WatchfilesReloader(autoreload.BaseReloader):
     def tick(self) -> Generator[None, None, None]:
         watched_files = list(self.watched_files(include_globs=False))
         roots = autoreload.common_roots(self.watched_roots(watched_files))
-        watcher = watchfiles.watch(*roots, debug=True)
+        watcher = watchfiles.watch(*roots, **self.watchfiles_settings)
         for file_changes in watcher:
             for _change, path in file_changes:
                 self.notify_file_changed(Path(path))
             yield
 
 
-def replaced_get_reloader() -> autoreload.BaseReloader:
-    return WatchfilesReloader()
+def run_with_reloader(main_func: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+    watchfiles_settings = getattr(settings, "DJANGO_WATCHFILES", {})
+    if watchfiles_settings.get("watch_filter"):
+        watchfiles_settings["watch_filter"] = import_string(
+            watchfiles_settings["watch_filter"]
+        )()
+    if "debug" not in watchfiles_settings:
+        watchfiles_settings["debug"] = kwargs["verbosity"] > 1
+
+    signal.signal(signal.SIGTERM, lambda *args: sys.exit(0))
+    try:
+        if os.environ.get(DJANGO_AUTORELOAD_ENV) == "true":
+            reloader = WatchfilesReloader(watchfiles_settings)
+            logger.info("Watching for file changes with %s", type(reloader).__name__)
+            start_django(reloader, main_func, *args, **kwargs)
+        else:
+            exit_code = restart_with_reloader()
+            sys.exit(exit_code)
+    except KeyboardInterrupt:
+        pass
 
 
-autoreload.get_reloader = replaced_get_reloader
+autoreload.run_with_reloader = run_with_reloader


### PR DESCRIPTION
I've replaced `autoreload.get_reloader` with `autoreload.run_with_reloader` to get verbosity level to setup debug mode. Other settings you can get from the project settings `DJANGO_WATCHFILES`, e.g.:
```python
DJANGO_WATCHFILES = {
    'watch_filter': 'path.to.custom_filter',
    'raise_interrupt': False,
    'debug': False,
}
```

