### PR TITLE
Fix Python 3.8 compatibility with Path.relative_to()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Fix Python 3.8 compatibility by replacing call to ``pathlib.Path.is_relative_to()``.
+
+  Thanks to Nathan Koch in `PR #68 <https://github.com/adamchainz/django-watchfiles/pull/68>`__.
+
 0.1.0 (2023-10-11)
 ------------------
 

--- a/src/django_watchfiles/__init__.py
+++ b/src/django_watchfiles/__init__.py
@@ -62,12 +62,15 @@ class WatchfilesReloader(autoreload.BaseReloader):
             # print("Path in watched files")
             return True
         for directory, globs in self.directory_globs.items():
-            if path.is_relative_to(directory):
+            try:
+                relative_path = path.relative_to(directory)
                 # print("Path is sub dir")
                 for glob in globs:
-                    if fnmatch.fnmatch(str(path.relative_to(directory)), glob):
+                    if fnmatch.fnmatch(str(relative_path), glob):
                         # print("Path is glob match")
                         return True
+            except ValueError:
+                pass
         # print("file filter", change, path)
         return False
 

--- a/src/django_watchfiles/__init__.py
+++ b/src/django_watchfiles/__init__.py
@@ -64,13 +64,14 @@ class WatchfilesReloader(autoreload.BaseReloader):
         for directory, globs in self.directory_globs.items():
             try:
                 relative_path = path.relative_to(directory)
+            except ValueError:
+                pass
+            else:
                 # print("Path is sub dir")
                 for glob in globs:
                     if fnmatch.fnmatch(str(relative_path), glob):
                         # print("Path is glob match")
                         return True
-            except ValueError:
-                pass
         # print("file filter", change, path)
         return False
 


### PR DESCRIPTION
Fixes #67 

This PR adds support for Python 3.8 that doesn't have `Path.is_relative_to` which was added in 3.9.

`is_relative_to` simply calls `relative_to` and catches the ValueError when thrown. We can do something similar here with the added benefit of only calling `relative_to` once per outer loop instead of each time on the inner loop.

I've tested this on 3.8 and it's working well. I don't currently have a project on any higher versions of python so I'm not easily able to test this out on other versions, but it shouldn't be any different.