### PR TITLE
ignore_permission_denied

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 dependencies = [
   "Django>=3.2",
-  "watchfiles",
+  "watchfiles>=0.20",
 ]
 urls = {Changelog = "https://github.com/adamchainz/django-watchfiles/blob/main/CHANGELOG.rst",Funding = "https://adamj.eu/books/",Repository = "https://github.com/adamchainz/django-watchfiles"}
 

--- a/src/django_watchfiles/__init__.py
+++ b/src/django_watchfiles/__init__.py
@@ -44,6 +44,7 @@ class MutableWatcher:
                 debounce=False,
                 rust_timeout=100,
                 yield_on_timeout=True,
+                ignore_permission_denied=True,
             ):
                 if self.change_event.is_set():
                     break


### PR DESCRIPTION
There is no reason to stop Django process and exit with error when watch encounters an incident such as an unreadable file, "permission denied" etc. So it seems reasonable to me to always pass `ignore_permission_denied=True` to `watchfiles`.

See also https://github.com/samuelcolvin/watchfiles/pull/224, where this flag was introduced.