### PR TITLE
Reload files after they fail with an import-time exception

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Reload files after they fail with an import-time exception, like a ``SyntaxError``.
+
+  Thanks to Deepak Angrula for the report in `Issue #148 <https://github.com/adamchainz/django-watchfiles/issues/148>`__.
+
 1.3.0 (2025-09-18)
 ------------------
 

--- a/tests/oops.py
+++ b/tests/oops.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+# Example file that would deliberately error on import
+1 / 0  # noqa: B018


### PR DESCRIPTION
Fixes #148.

Tested by using the new example project from #169 and editing `views.py` to introduce a `SyntaxError` for instant failure, or `import time; time.sleep(1); 1 / 0` for a delayed one.