### PR TITLE
Re-enable debounce

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+* Use watchfiles’ debounce option to batch rapid file changes into a single reload.
+  This feature avoids multiple reloads when multiple file changes occur in quick succession.
+  Such batched changes can occur include when one file is saved and then updated by a formatter, or when multiple files are changed when you ``git switch`` to another branch.
+
+  `PR #172 <https://github.com/adamchainz/django-watchfiles/pull/172>`__.
+
 * Reload files after they fail with an import-time exception, like a ``SyntaxError``.
 
   Thanks to Deepak Angrula for the report in `Issue #148 <https://github.com/adamchainz/django-watchfiles/issues/148>`__.

--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,15 @@ __ https://docs.djangoproject.com/en/stable/ref/django-admin/#runserver
   ``StatReloader`` can take one second or more to detect changes, while ``WatchfilesReloader`` can take as little as 50 milliseconds.
   This means that ``runserver`` starts reloading your code more quickly, and you can iterate more rapidly.
 
+* **Batched reloads**
+
+  Sometimes multiple file changes can occur in quick succession, such as when one file is saved and then updated by a formatter, or when multiple files are changed when you ``git switch`` to another branch.
+  In such cases, ``StatReloader`` can trigger multiple reloads, unnecessarily slowing down progress, or it can miss some changes, leading to old code being left running.
+  ``WatchfilesReloader`` instead batches changes, using watchfiles’ `debounce feature <https://watchfiles.helpmanual.io/api/watch/#:~:text=debounce,-int>`__, so that multiple changes will only trigger a single reload.
+
+  ``WatchfilesReloader`` uses watchfiles’ defaults here, waiting for changes within a 50 millisecond window, and repeating this wait for up to 1600 milliseconds, as long as changes keep occurring.
+  These values provide a good balance between responsiveness and batching.
+
 History
 -------
 

--- a/src/django_watchfiles/__init__.py
+++ b/src/django_watchfiles/__init__.py
@@ -55,7 +55,6 @@ class MutableWatcher:
                 *self.roots,
                 watch_filter=self.filter,
                 stop_event=self.stop_event,
-                debounce=False,
                 rust_timeout=100,
                 yield_on_timeout=True,
             ):


### PR DESCRIPTION
This was disabled in dc1af91876a6a7d6311268f23088fb83657df7c9, but I’m not sure why. I think it’s best to enable it!

@orf any memory why you disabled it?