### PR TITLE
Improve Coverage.py configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: coverage-data-${{ matrix.python-version }}
-        path: '${{ github.workspace }}/.coverage.*'
+        path: '${{ github.workspace }}/.coverage/*'
         include-hidden-files: true
         if-no-files-found: error
 
@@ -70,7 +70,7 @@ jobs:
       - name: Download data
         uses: actions/download-artifact@v8
         with:
-          path: ${{ github.workspace }}
+          path: .coverage
           pattern: coverage-data-*
           merge-multiple: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ ini_options.xfail_strict = true
 
 [tool.coverage]
 run.branch = true
+run.data_file = ".coverage/cov"
 run.parallel = true
 run.source = [
   "django_watchfiles",
@@ -129,6 +130,8 @@ paths.source = [
   ".tox/**/site-packages",
 ]
 report.show_missing = true
+report.skip_covered = true
+report.skip_empty = true
 
 [tool.mypy]
 enable_error_code = [


### PR DESCRIPTION
Hide data files within a directory to avoid cluttering the repository root, and minimize reports.
